### PR TITLE
fix: include mix exs template at compile time

### DIFF
--- a/lib/ex_united.ex
+++ b/lib/ex_united.ex
@@ -275,6 +275,10 @@ defmodule ExUnited do
   ```
   """
 
+  @mix_exs_template "../ex_united/mix.exs.eex"
+                    |> Path.expand(__ENV__.file)
+                    |> File.read!()
+
   @emptyconfig Path.expand(
                  "../ex_united/config.exs",
                  __ENV__.file
@@ -589,9 +593,7 @@ defmodule ExUnited do
       |> Keyword.put(:elixirc_paths, elixirc_paths(opts, spec))
       |> Keyword.put(:deps, deps(config, opts, spec))
 
-    "../ex_united/mix.exs.eex"
-    |> Path.expand(__ENV__.file)
-    |> EEx.eval_file(
+    EEx.eval_string(@mix_exs_template,
       project: project,
       all_env: read_config(opts, spec),
       supervised: supervised(spec)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExUnited.MixProject do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.1.6"
 
   def project do
     [


### PR DESCRIPTION
For some reason Gitlab cache does not like the mix exs loading part. Maybe this can fix it.